### PR TITLE
Bump golang builder ver to 1.16.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14.15 as builder
+FROM golang:1.16.10 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/jpeeler/podpreset-crd


### PR DESCRIPTION
Addressing CVE-2021-38297