### PR TITLE
Bump golang builder ver to 1.17.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17.4 as builder
+FROM golang:1.17.6 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/jpeeler/podpreset-crd


### PR DESCRIPTION
Addressing security issues:
- CVE-2021-44716
- CVE-2021-44717