### PR TITLE
Bump go to 1.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19.2 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/jpeeler/podpreset-crd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpeeler/podpreset-crd
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b


### PR DESCRIPTION
TODO:
- [x] after this merges, bump version in [kyma](https://github.com/kyma-project/kyma/blob/619ef81a75af174a1289ecc2fee159e7dbcb9de5/resources/cluster-essentials/values.yaml#L18-L22)